### PR TITLE
fix: change all to specific fields in region queries

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -66,7 +66,7 @@ korv_region_get_with_id:
   methods: GET
 
 korv_region_delete:
-  path: /region
+  path: /region/{id}
   controller: App\Controller\RegionController::deleteRegion
   methods: DELETE
 

--- a/src/Controller/LocalController.php
+++ b/src/Controller/LocalController.php
@@ -151,6 +151,6 @@ class LocalController extends AbstractController
             return $this->json(['status' => 404, 'message' => 'Não foi possível visualizar este local, porque o local informado não existe.'], 404, ['Content-Type'=>'application/json; charset=utf-8']);
         }
 
-        return $this->json($currentLocal, 200, ['Content-Type'=>'application/json; charset=utf-8']);
+        return $this->json($currentLocal[0], 200, ['Content-Type'=>'application/json; charset=utf-8']);
     }
 }

--- a/src/Controller/RegionController.php
+++ b/src/Controller/RegionController.php
@@ -65,24 +65,20 @@ class RegionController extends AbstractController
         return $this->json(['status' => 200, 'message' => 'Região atualizada com sucesso.'], 200, ['Content-Type'=>'application/json; charset=utf-8']);
     }
 
-    #[Route('/region', name: 'korv_region_delete', methods: 'DELETE')]
-    public function deleteRegion(Request $request, EntityManagerInterface $entityManager): Response
+    #[Route('/region/{id}', name: 'korv_region_delete', methods: 'DELETE')]
+    public function deleteRegion(EntityManagerInterface $entityManager, int $id): Response
     {
         $accessResponse = $this->userAuthenticatedVerifier->getHasAccessInCurrentRoute(['KORV_ADMIN']);
         if ($accessResponse !== null) {
             return $accessResponse;
         }
 
-        $resultJson = json_decode($request->getContent(), true);
-        if ( !is_array($resultJson) ) {
-            return $this->json(['status' => 422, 'message' => 'Não foi possível excluir essa região, porque faltam informações para realizar a exclusão.'], 422, ['Content-Type'=>'application/json; charset=utf-8']);
-        }
-        $regionExists = $entityManager->getRepository(Region::class)->findOneByIdExists($resultJson["id"]);
+        $regionExists = $entityManager->getRepository(Region::class)->findOneByIdExists($id);
         if (!$regionExists) {
             return $this->json(['status' => 404, 'message' => 'Não foi possível excluir essa região, porque a região informada não existe.'], 404, ['Content-Type'=>'application/json; charset=utf-8']);
         }
 
-        $region = $entityManager->getRepository(Region::class)->find($resultJson["id"]);
+        $region = $entityManager->getRepository(Region::class)->find($id);
 
         $entityManager->remove($region);
         $entityManager->flush();
@@ -98,7 +94,7 @@ class RegionController extends AbstractController
             return $accessResponse;
         }
 
-        $regions = $entityManager->getRepository(Region::class)->findAll();
+        $regions = $entityManager->getRepository(Region::class)->returnAllRegions();
 
         return $this->json($regions, 200, ['Content-Type'=>'application/json; charset=utf-8']);
     }
@@ -111,11 +107,11 @@ class RegionController extends AbstractController
             return $accessResponse;
         }
 
-        $currentRegion = $entityManager->getRepository(Region::class)->find($id);
+        $currentRegion = $entityManager->getRepository(Region::class)->findOneByIdExists($id);
         if (!$currentRegion) {
             return $this->json(['status' => 404, 'message' => 'Não foi possível visualizar essa região, porque a região informada não existe.'], 404, ['Content-Type'=>'application/json; charset=utf-8']);
         }
 
-        return $this->json($currentRegion, 200, ['Content-Type'=>'application/json; charset=utf-8']);
+        return $this->json($currentRegion[0], 200, ['Content-Type'=>'application/json; charset=utf-8']);
     }
 }

--- a/src/Repository/RegionRepository.php
+++ b/src/Repository/RegionRepository.php
@@ -27,9 +27,18 @@ class RegionRepository extends ServiceEntityRepository
     public function findOneByIdExists(int $id): array
     {
         return $this->createQueryBuilder('region')
+            ->select('region.id, region.name')
             ->andWhere('region.id = :id')
             ->setParameter('id', $id)
             ->setMaxResults(1)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function returnAllRegions() : array
+    {
+        return $this->createQueryBuilder('region')
+            ->select("region.id", "region.name")
             ->getQuery()
             ->getResult();
     }


### PR DESCRIPTION
Change queries relationated region because we add a field can be return error when not filter Local field. That field cause an error because of own cardinality.

Obs: We change get routes too because that return an array ratter than single object owner who return in that query.