### PR TITLE
feat(KRV-09): create management of sensors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/doctrine-bundle": "^2.10",
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^2.16",
+        "guzzlehttp/guzzle": "^7.8",
         "lexik/jwt-authentication-bundle": "^2.19",
         "nelmio/cors-bundle": "^2.3",
         "phpdocumentor/reflection-docblock": "^5.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8376fe5ef48e52cbbc8f66c1effad061",
+    "content-hash": "83481ab584cea870d265bebd352c803a",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -1388,6 +1388,331 @@
             "time": "2023-01-14T14:17:03+00:00"
         },
         {
+            "name": "guzzlehttp/guzzle",
+            "version": "7.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "reference": "1110f66a6530a40fe7aea0378fe608ee2b2248f9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.5.3 || ^2.0.1",
+                "guzzlehttp/psr7": "^1.9.1 || ^2.5.1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.1",
+                "ext-curl": "*",
+                "php-http/client-integration-tests": "dev-master#2c025848417c1135031fdf9c728ee53d0a7ceaee as 3.0.999",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-27T10:20:53+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.1",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/promises",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-03T15:11:55+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "reference": "be45764272e8873c72dbe3d2edcfdfcc3bc9f727",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.1",
+                "http-interop/http-factory-tests": "^0.9",
+                "phpunit/phpunit": "^8.5.29 || ^9.5.23"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/psr7",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-27T10:13:57+00:00"
+        },
+        {
             "name": "lcobucci/clock",
             "version": "3.0.0",
             "source": {
@@ -2291,6 +2616,166 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
             "name": "psr/link",
             "version": "2.0.1",
             "source": {
@@ -2395,6 +2880,50 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
             "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "symfony/asset",

--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -81,6 +81,13 @@ nelmio_cors:
             allow_methods: [ 'GET', 'PUT', 'DELETE' ]
             max_age: 3600
             hosts: [ '^api\.' ]
+        '^/local/{id}/sensors':
+            origin_regex: true
+            allow_origin: [ '%env(CORS_ALLOW_ORIGIN)%' ]
+            allow_headers: [ 'X-Custom-Auth' ]
+            allow_methods: [ 'GET' ]
+            max_age: 3600
+            hosts: [ '^api\.' ]
         '^/locals/':
             origin_regex: true
             allow_origin: [ '%env(CORS_ALLOW_ORIGIN)%' ]
@@ -88,3 +95,25 @@ nelmio_cors:
             allow_methods: [ 'GET' ]
             max_age: 3600
             hosts: [ '^api\.' ]
+        '^/sensor/':
+            origin_regex: true
+            allow_origin: [ '%env(CORS_ALLOW_ORIGIN)%' ]
+            allow_headers: [ 'X-Custom-Auth' ]
+            allow_methods: [ 'POST' ]
+            max_age: 3600
+            hosts: [ '^api\.' ]
+        '^/sensor/{id}':
+            origin_regex: true
+            allow_origin: [ '%env(CORS_ALLOW_ORIGIN)%' ]
+            allow_headers: [ 'X-Custom-Auth' ]
+            allow_methods: [ 'GET', 'PUT', 'DELETE' ]
+            max_age: 3600
+            hosts: [ '^api\.' ]
+        '^/sensors/local/{id}':
+            origin_regex: true
+            allow_origin: [ '%env(CORS_ALLOW_ORIGIN)%' ]
+            allow_headers: [ 'X-Custom-Auth' ]
+            allow_methods: [ 'GET' ]
+            max_age: 3600
+            hosts: [ '^api\.' ]
+

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -19,14 +19,18 @@ security:
         ~
 
   access_control:
-    - { path: ^/login,           roles: PUBLIC_ACCESS }
-    - { path: ^/user,            roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/user/:id,        roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/user/:id/status, roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/users,           roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/region,          roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/region/:id,      roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/regions,         roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/local,           roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/local/:id,       roles: IS_AUTHENTICATED_FULLY }
-    - { path: ^/locals,          roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/login,                roles: PUBLIC_ACCESS }
+    - { path: ^/user,                 roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/user/:id,             roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/user/:id/status,      roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/users,                roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/region,               roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/region/:id,           roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/regions,              roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/local,                roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/local/:id,            roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/local/:id/sensors,    roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/locals,               roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/sensor,               roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/sensor/:id,           roles: IS_AUTHENTICATED_FULLY }
+    - { path: ^/sensors/local/:id,    roles: IS_AUTHENTICATED_FULLY }

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -95,4 +95,38 @@ korv_local_get_with_id:
   controller: App\Controller\LocalController::getLocalWithId
   methods: GET
 
+korv_local_get_with_sensors:
+  path: /local/{id}/sensors
+  controller: App\Controller\LocalController::getLocalWithSensors
+  methods: GET
+
+korv_sensor_create:
+  path: /sensor
+  controller: App\Controller\SensorController::postSensor
+  methods: POST
+
+korv_sensor_put:
+  path: /sensor/{id}
+  controller: App\Controller\SensorController::putSensor
+  methods: PUT
+
+korv_sensor_delete:
+  path: /sensor/{id}
+  controller: App\Controller\SensorController::deleteSensor
+  methods: DELETE
+
+korv_sensor_get_with_id:
+  path: /sensor/{id}
+  controller: App\Controller\SensorController::getSensorWithId
+  methods: GET
+
+korv_sensor_get_inside_of_local:
+  path: /sensors/local/{id}
+  controller: App\Controller\SensorController::getSensorsInsideOfLocal
+  methods: GET
+
+korv_sensor_status_update:
+  path: /sensors/status/update
+  controller: App\Controller\SensorController::putRefreshStatusSensors
+  methods: PUT
 

--- a/src/Controller/SensorController.php
+++ b/src/Controller/SensorController.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\Local;
+use App\Entity\Sensor;
+use App\Security\UserAuthenticatedVerifier;
+use App\Shared\ResponseMessage;
+use App\Validations\RequestPropertiesValidation;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+class SensorController extends AbstractController
+{
+    private UserAuthenticatedVerifier $userAuthenticatedVerifier;
+    private RequestPropertiesValidation $propertiesValidation;
+    private ResponseMessage $responseMessage;
+
+    public function __construct(ResponseMessage $responseMessage, UserAuthenticatedVerifier $userAuthenticatedVerifier, RequestPropertiesValidation $propertiesValidation)
+    {
+        $this->userAuthenticatedVerifier = $userAuthenticatedVerifier;
+        $this->propertiesValidation = $propertiesValidation;
+        $this->responseMessage = $responseMessage;
+    }
+    #[Route('/sensor', name: 'korv_sensor_create', methods: 'POST')]
+    public function postSensor(Request $request, EntityManagerInterface $entityManager): Response
+    {
+        $accessResponse = $this->userAuthenticatedVerifier->getHasAccessInCurrentRoute(['KORV_ADMIN']);
+        if ($accessResponse !== null) {
+            return $accessResponse;
+        }
+
+        $requestJSON = json_decode($request->getContent(), true);
+        if ($requestJSON === null) {
+            return $this->responseMessage->makeResponsePostMessage(442, 'Não foi possível cadastrar esse sensor, porque é necessário enviar um payload para essa requisição.');
+        }
+        if ( count($requestJSON) < 3 ) {
+            return $this->responseMessage->makeResponsePostMessage(442, 'Não foi possível cadastrar esse sensor, porque faltou algumas informações nesse envio.');
+        }
+
+        $sensor = new Sensor();
+        $hasCorrectRequest = $this->propertiesValidation->isBothHasTheSameProperties($sensor, $requestJSON, ['id', 'status', 'isActivated']);
+        if (!$hasCorrectRequest) {
+            return $this->responseMessage->makeResponsePostMessage(442, 'Não foi possível cadastrar esse sensor, porque envio das informações dessa rota está incorreta.');
+        }
+
+        $localRefer = $entityManager->getRepository(Local::class)->find($requestJSON['local']);
+        if ( $localRefer === null ) {
+            return $this->responseMessage->makeResponsePostMessage(400, 'Não foi possível cadastrar esse sensor, porque o local informado não existe.');
+        }
+
+        $sensor->setName($requestJSON['name']);
+        $sensor->setType($requestJSON['type']);
+        $sensor->setStatus(false);
+        $sensor->setIsActivated(true);
+
+        $sensor->setLocal($localRefer);
+
+        $entityManager->persist($sensor);
+        $entityManager->flush();
+
+        return $this->responseMessage->makeResponsePostMessage(200, 'Sensor cadastrado com sucesso.');
+    }
+
+    #[Route('/sensor/{id}', name: 'korv_sensor_put', methods: 'PUT')]
+    public function putSensor(Request $request, EntityManagerInterface $entityManager, int $id): Response
+    {
+        $accessResponse = $this->userAuthenticatedVerifier->getHasAccessInCurrentRoute(['KORV_ADMIN']);
+        if ($accessResponse !== null) {
+            return $accessResponse;
+        }
+
+        $requestJSON = json_decode($request->getContent(), true);
+        if ($requestJSON === null) {
+            return $this->responseMessage->makeResponsePostMessage(442, 'Não foi possível atualizar esse sensor, porque é necessário enviar um payload para essa requisição.');
+        }
+        if ( count($requestJSON) < 5 ) {
+            return $this->responseMessage->makeResponsePostMessage(442, 'Não foi possível atualizar esse sensor, porque faltou algumas informações nesse envio.');
+        }
+
+        $sensorCurrent = new Sensor();
+        $hasCorrectRequest = $this->propertiesValidation->isBothHasTheSameProperties($sensorCurrent, $requestJSON, ['id']);
+        if (!$hasCorrectRequest) {
+            return $this->responseMessage->makeResponsePostMessage(442, 'Não foi possível atualizar esse sensor, porque envio das informações dessa rota está incorreta.');
+        }
+
+        $sensorCurrent = $entityManager->getRepository(Sensor::class)->find($id);
+        if ( $sensorCurrent === null ) {
+            return $this->responseMessage->makeResponsePostMessage(400, 'Não foi possível atualizar esse sensor, porque o sensor informado não existe.');
+        }
+
+        $localRefer = $entityManager->getRepository(Local::class)->find($requestJSON['local']);
+        if ( $localRefer === null ) {
+            return $this->responseMessage->makeResponsePostMessage(400, 'Não foi possível atualizar esse sensor, porque o local informado não existe.');
+        }
+
+        $sensorCurrent->setName($requestJSON['name']);
+        $sensorCurrent->setType($requestJSON['type']);
+        $sensorCurrent->setStatus($requestJSON['status']);
+        $sensorCurrent->setIsActivated($requestJSON['isActivated']);
+        $sensorCurrent->setLocal($localRefer);
+
+        $entityManager->flush();
+
+        return $this->responseMessage->makeResponsePostMessage(200, 'Sensor atualizado com sucesso.');
+    }
+
+    #[Route('/sensor/{id}', name: 'korv_sensor_delete', methods: 'DELETE')]
+    public function deleteSensor(EntityManagerInterface $entityManager, int $id): Response
+    {
+        $accessResponse = $this->userAuthenticatedVerifier->getHasAccessInCurrentRoute(['KORV_ADMIN']);
+        if ($accessResponse !== null) {
+            return $accessResponse;
+        }
+
+        $sensorToBeDeleted = $entityManager->getRepository(Sensor::class)->find($id);
+        if ( $sensorToBeDeleted === null ) {
+            return $this->responseMessage->makeResponsePostMessage(400, 'Não foi possível excluir esse sensor, porque o sensor informado não existe.');
+        }
+
+        $entityManager->remove($sensorToBeDeleted);
+        $entityManager->flush();
+
+        return $this->responseMessage->makeResponsePostMessage(200, 'Sensor excluído com sucesso.');
+    }
+
+    #[Route('/sensor/{id}', name: 'korv_sensor_get_with_id', methods: 'GET')]
+    public function getSensorWithId(EntityManagerInterface $entityManager, int $id): Response
+    {
+        $accessResponse = $this->userAuthenticatedVerifier->getHasAccessInCurrentRoute(['KORV_ADMIN', 'EMPLOYEE']);
+        if ($accessResponse !== null) {
+            return $accessResponse;
+        }
+
+        $currentSensor = $entityManager->getRepository(Sensor::class)->findSensorById($id);
+        if (!$currentSensor) {
+            return $this->json(['status' => 404, 'message' => 'Não foi possível visualizar este local, porque o local informado não existe.'], 404, ['Content-Type'=>'application/json; charset=utf-8']);
+        }
+
+        return $this->json($currentSensor[0], 200, ['Content-Type'=>'application/json; charset=utf-8']);
+    }
+
+    #[Route('/sensors/local/{id}', name: 'korv_sensor_get_inside_of_local', methods: 'GET')]
+    public function getSensorsInsideOfLocal(EntityManagerInterface $entityManager, int $id): Response
+    {
+        $accessResponse = $this->userAuthenticatedVerifier->getHasAccessInCurrentRoute(['KORV_ADMIN', 'EMPLOYEE']);
+        if ($accessResponse !== null) {
+            return $accessResponse;
+        }
+
+        $currentLocal = $entityManager->getRepository(Local::class)->findLocalById($id);
+        if ( count($currentLocal) < 1 ) {
+            return $this->responseMessage->makeResponsePostMessage(400, 'Não foi possível consultar os sensores desse local, porque o local informado não existe.');
+        }
+
+        $sensorsInsideOfLocal = $entityManager->getRepository(Sensor::class)->findSensorsByLocal($currentLocal[0]['id']);
+        if ( count($sensorsInsideOfLocal) < 1 ) {
+            return $this->responseMessage->makeResponsePostMessage(400, 'Não foi possível consultar os sensores desse local, porque não há sensores cadastrados nesse local.');
+        }
+
+        return $this->json($sensorsInsideOfLocal, 200, ['Content-Type'=>'application/json; charset=utf-8']);
+    }
+
+    #[Route('/sensors/status/update', name: 'korv_local_put_sensors_refresh', methods: 'PUT')]
+    public function putRefreshStatusSensors(EntityManagerInterface $entityManager): Response
+    {
+        $accessResponse = $this->userAuthenticatedVerifier->getHasAccessInCurrentRoute(['KORV_ADMIN', 'EMPLOYEE']);
+        if ($accessResponse !== null) {
+            return $accessResponse;
+        }
+
+        $listLocal = $entityManager->getRepository(Local::class)->findAll();
+        foreach ( $listLocal as $local )
+        {
+            $whichTypeSensorIsUsed = $entityManager->getRepository(Sensor::class)->findWhichTypeSensorIsCreatedByLocal(1);
+            if ( count($whichTypeSensorIsUsed) > 0 ) {
+
+                $newStatus = $local->updateSensorStatus($local->getAddress());
+                if ( $newStatus === null ) {
+                    continue;
+                }
+
+                foreach ( $whichTypeSensorIsUsed as $typeSensor ) {
+
+                    $sensorSpecific = $entityManager->getRepository(Sensor::class)->findSensorTypeByLocal($local->getId(), $typeSensor["type"]);
+                    if ($sensorSpecific !== null) {
+                        $sensor = $entityManager->getRepository(Sensor::class)->find($sensorSpecific['id']);
+                        $statusBoolean = boolval($newStatus["sensors"][$typeSensor["type"]]);
+                        if ( $sensor->isStatus() !== $statusBoolean ) {
+                            $sensor->setStatus($statusBoolean);
+                            $entityManager->flush();
+                        }
+                    }
+                }
+            }
+        }
+
+        return $this->responseMessage->makeResponsePostMessage(200, 'Sensores atualizados com sucesso.');
+    }
+}

--- a/src/Entity/Sensor.php
+++ b/src/Entity/Sensor.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\SensorRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: SensorRepository::class)]
+class Sensor
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 120)]
+    private ?string $name = null;
+
+    #[ORM\Column(length: 40)]
+    private ?string $type = null;
+
+    #[ORM\Column]
+    private ?bool $status = null;
+
+    #[ORM\Column]
+    private ?bool $isActivated = null;
+
+    #[ORM\ManyToOne(inversedBy: 'sensors')]
+    #[ORM\JoinColumn(nullable: false)]
+    private ?Local $local = null;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function setId(int $id): static
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): static
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): static
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function isStatus(): ?bool
+    {
+        return $this->status;
+    }
+
+    public function setStatus(bool $status): static
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function isIsActivated(): ?bool
+    {
+        return $this->isActivated;
+    }
+
+    public function setIsActivated(bool $isActivated): static
+    {
+        $this->isActivated = $isActivated;
+
+        return $this;
+    }
+
+    public function getLocal(): ?Local
+    {
+        return $this->local;
+    }
+
+    public function setLocal(?Local $local): static
+    {
+        $this->local = $local;
+
+        return $this;
+    }
+}

--- a/src/Repository/SensorRepository.php
+++ b/src/Repository/SensorRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Sensor;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Sensor>
+ *
+ * @method Sensor|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Sensor|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Sensor[]    findAll()
+ * @method Sensor[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class SensorRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Sensor::class);
+    }
+
+    public function findSensorById(int $id)
+    {
+        return $this->createQueryBuilder('sensor')
+            ->select('sensor.id, sensor.name, sensor.type, sensor.status, sensor.isActivated')
+            ->AndWhere('sensor.id = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findSensorsByLocal(int $idLocal): array
+    {
+        return $this->createQueryBuilder('sensor')
+            ->select('sensor.id, sensor.name, sensor.type, sensor.status, sensor.isActivated')
+            ->andWhere('sensor.local = :localId')
+            ->setParameter('localId', $idLocal)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findSensorTypeByLocal(int $idLocal, string $typeSensor): array|null
+    {
+        return $this->createQueryBuilder('sensor')
+            ->select('sensor.id, sensor.name, sensor.type, sensor.status, sensor.isActivated')
+            ->andWhere('sensor.local = :localId')
+            ->andWhere('sensor.type = :typeSensor')
+            ->setParameter('localId', $idLocal)
+            ->setParameter('typeSensor', $typeSensor)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findWhichTypeSensorIsCreatedByLocal(int $idLocal): array
+    {
+        return $this->createQueryBuilder('sensor')
+            ->select('sensor.type')
+            ->andWhere('sensor.local = :localId')
+            ->setParameter('localId', $idLocal)
+            ->distinct()
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/templates/sensor/index.html.twig
+++ b/templates/sensor/index.html.twig
@@ -1,0 +1,20 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Hello SensorController!{% endblock %}
+
+{% block body %}
+<style>
+    .example-wrapper { margin: 1em auto; max-width: 800px; width: 95%; font: 18px/1.5 sans-serif; }
+    .example-wrapper code { background: #F5F5F5; padding: 2px 6px; }
+</style>
+
+<div class="example-wrapper">
+    <h1>Hello {{ controller_name }}! ✅</h1>
+
+    This friendly message is coming from:
+    <ul>
+        <li>Your controller at <code><a href="{{ '/var/www/KorvApi/src/Controller/SensorController.php'|file_link(0) }}">src/Controller/SensorController.php</a></code></li>
+        <li>Your template at <code><a href="{{ '/var/www/KorvApi/templates/sensor/index.html.twig'|file_link(0) }}">templates/sensor/index.html.twig</a></code></li>
+    </ul>
+</div>
+{% endblock %}


### PR DESCRIPTION
Create entity with params we use in that version and controller to manage sensors of application.

Create route can be possible add sensor following a existing local in application.

Create route to update existing sensor based in all params of that Entity.

Create route can be possile delete sensor of application.

Create a route to query all informations about a specfic sensor without local registered.

Create query to select all sensors with informations about current local .

Create route for only return sensors linked in local informed.

Create a way between API and controller who view sensors each one local and refresh If status is different of controller.

For that communication, I need to use guzzlehttp/guzzle to construct requisition to external at internal API to receive new informations about sensors.

New routes:
- POST /sensor
- PUT /sensor/{id}
- PUT /sensor/status/update
- DELETE /sensor/{id}
- GET /sensor/{id}
- GET /sensor/local/{id}
- GET /local/{id}/sensors

Resolves: KRV-24, KRV-36, KRV-37, KRV-38, KRV-39, KRV-40, KRV-41, KRV-42